### PR TITLE
Fix: generate route tree before type checking in dev check

### DIFF
--- a/src/apx/assets/entrypoint.ts
+++ b/src/apx/assets/entrypoint.ts
@@ -2,6 +2,7 @@ import { build, createServer, type InlineConfig, type Plugin } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
+import { Generator, getConfig } from "@tanstack/router-generator";
 import type { IncomingMessage, ServerResponse } from "http";
 import {
   LoggerProvider,
@@ -362,6 +363,18 @@ async function runBuild() {
   await build(config);
 }
 
+async function runGenerate() {
+  const config = getConfig({
+    target: "react",
+    autoCodeSplitting: true,
+    routesDirectory: `${uiRoot}/routes`,
+    generatedRouteTree: `${uiRoot}/types/routeTree.gen.ts`,
+  });
+
+  const generator = new Generator({ config, root: uiRoot });
+  await generator.run();
+}
+
 // Main entry point
 if (mode === "dev") {
   runDev().catch((err) => {
@@ -373,7 +386,12 @@ if (mode === "dev") {
     logError(`Failed to build: ${err}`);
     process.exit(1);
   });
+} else if (mode === "generate") {
+  runGenerate().catch((err) => {
+    logError(`Failed to generate route tree: ${err}`);
+    process.exit(1);
+  });
 } else {
-  logError(`Invalid mode: ${mode}. Expected "dev" or "build".`);
+  logError(`Invalid mode: ${mode}. Expected "dev", "build", or "generate".`);
   process.exit(1);
 }

--- a/src/cli/frontend/mod.rs
+++ b/src/cli/frontend/mod.rs
@@ -1,3 +1,3 @@
 pub mod build;
-mod common;
+pub(crate) mod common;
 pub mod dev;

--- a/src/common.rs
+++ b/src/common.rs
@@ -18,6 +18,7 @@ pub const ENTRYPOINT_DEV_DEPS: &[&str] = &[
     "@tailwindcss/vite",
     "@vitejs/plugin-react",
     "@tanstack/router-plugin",
+    "@tanstack/router-generator",
     "@opentelemetry/sdk-logs",
     "@opentelemetry/exporter-logs-otlp-http",
     "@opentelemetry/api-logs",


### PR DESCRIPTION
## Summary
- Fixes #67 — `apx dev check` fails when `routeTree.gen.ts` hasn't been generated yet
- Adds a `"generate"` mode to `entrypoint.ts` using `@tanstack/router-generator`'s `Generator` class to produce the route tree file without starting Vite
- Invokes route tree generation from `check.rs` before running `tsc`/`ty check`

## Changes
- **`src/common.rs`** — Added `@tanstack/router-generator` to `ENTRYPOINT_DEV_DEPS`
- **`src/apx/assets/entrypoint.ts`** — Added `runGenerate()` function and `"generate"` mode dispatch
- **`src/cli/frontend/mod.rs`** — Made `common` module `pub(crate)` so `check.rs` can use `prepare_frontend_args`
- **`src/cli/dev/check.rs`** — Added `generate_route_tree()` step before tsc/ty checks

## Test plan
- [ ] Delete `routeTree.gen.ts` from an existing project, run `uv run apx dev check` — should succeed
- [ ] Run `uv run apx dev start` — should still work normally (Vite plugin generates routes as before)
- [ ] Run `uv run apx ui build` — should still work normally
- [ ] `cargo check` passes, `cargo test` passes (126/126)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)