### PR TITLE
Fix: path parameters must always be required per OpenAPI spec

### DIFF
--- a/crates/core/src/openapi/ir/normalize.rs
+++ b/crates/core/src/openapi/ir/normalize.rs
@@ -617,11 +617,18 @@ fn normalize_param(p: &Parameter) -> ParamIR {
         _ => ParamLocation::Query,
     };
 
+    // OpenAPI 3.0 spec: path parameters are always required
+    let required = if location == ParamLocation::Path {
+        true
+    } else {
+        p.required
+    };
+
     ParamIR {
         name: p.name.clone(),
         original_name: p.name.clone(),
         ty,
-        required: p.required,
+        required,
         location,
     }
 }

--- a/crates/core/src/openapi/mod.rs
+++ b/crates/core/src/openapi/mod.rs
@@ -4011,4 +4011,51 @@ export function useGetCatBuggy<TData = { data: { meow: string } }>(
         // Should generate functions without any types section
         assert!(ts_code.contains("ping"), "Should generate ping function");
     }
+
+    #[test]
+    fn test_path_params_required_even_when_omitted() {
+        // Path parameters omit `required` (common in FastAPI-generated specs).
+        // Per OpenAPI 3.0 spec, path params are always required.
+        let openapi_json = r##"{
+  "openapi": "3.1.0",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "paths": {
+    "/scans/{scan_id}": {
+      "get": {
+        "operationId": "getScan",
+        "parameters": [
+          { "name": "scan_id", "in": "path", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "id": { "type": "string" } } } } }
+          }
+        }
+      }
+    }
+  }
+}"##;
+
+        let ts_code = generate_and_verify(openapi_json);
+        println!("=== PATH PARAMS REQUIRED ===\n{ts_code}\n=== END ===");
+
+        // Fetch function: params must be non-optional
+        assert!(
+            ts_code.contains("params: GetScanParams, options?"),
+            "Fetch function params should be required (non-optional)"
+        );
+
+        // Hook: options object must be required (contains required params)
+        assert!(
+            ts_code.contains("(options: { params: GetScanParams"),
+            "Hook options should be required with required params field"
+        );
+
+        // Hook should use options.params, not options?.params
+        assert!(
+            ts_code.contains("options.params"),
+            "Should use options.params (non-optional access)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Enforce `required: true` for path parameters in `normalize_param()`, per the [OpenAPI 3.0 spec](https://spec.openapis.org/oas/v3.0.3#parameter-object) which mandates path params are always required
- Fixes issue where FastAPI-generated specs omit `required` for path params (since it's implied), causing generated TypeScript hooks to treat params as optional and producing `tsc` errors under `strict: true`
- Add test verifying path params without explicit `required` field generate non-optional TypeScript params

Closes #79

## Test plan

- [x] `cargo test -p apx-core openapi` — all 103 tests pass
- [x] `just fmt` — clean
- [x] `just check` — all checks pass
- [x] New test `test_path_params_required_even_when_omitted` validates fetch function and hook signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)