### PR TITLE
✨ feat: add uv workspace composability and project discovery

### DIFF
--- a/crates/cli/src/build.rs
+++ b/crates/cli/src/build.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use tokio::process::Command;
 use tracing::debug;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::api_generator::generate_openapi;
 use apx_core::common::{
@@ -39,7 +39,7 @@ pub async fn run(args: BuildArgs) -> i32 {
 }
 
 async fn run_inner(args: BuildArgs) -> Result<(), String> {
-    let app_path = resolve_app_dir(args.app_path);
+    let app_path = find_app_dir(args.app_path)?;
     let build_dir = app_path.join(&args.build_path);
 
     println!("Building project in {}", app_path.display());

--- a/crates/cli/src/common.rs
+++ b/crates/cli/src/common.rs
@@ -1,12 +1,115 @@
 //! Common types shared across CLI commands
 
 use clap::ValueEnum;
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml_edit::DocumentMut;
+use tracing::debug;
+use walkdir::WalkDir;
+
+const MAX_DISCOVERY_DEPTH: usize = 5;
 
 /// Resolve the app directory from an optional path argument.
 /// Falls back to the current working directory, or "." if that fails.
+/// Used by `init` which creates new projects and does not need discovery.
 pub fn resolve_app_dir(app_path: Option<PathBuf>) -> PathBuf {
     app_path.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+/// Find an existing apx project directory, with automatic discovery.
+///
+/// If an explicit path is given, returns it directly.
+/// Otherwise checks CWD for a `pyproject.toml` with `[tool.apx]`, and if not
+/// found, scans subdirectories up to 5 levels deep.
+pub fn find_app_dir(app_path: Option<PathBuf>) -> Result<PathBuf, String> {
+    if let Some(path) = app_path {
+        return Ok(path);
+    }
+
+    let cwd = std::env::current_dir()
+        .map_err(|e| format!("Failed to determine current directory: {e}"))?;
+
+    if has_apx_config(&cwd.join("pyproject.toml")) {
+        debug!("apx config found in current directory");
+        return Ok(cwd);
+    }
+
+    discover_apx_project(&cwd)
+}
+
+/// Search subdirectories up to 5 levels deep for an apx project.
+fn discover_apx_project(root: &Path) -> Result<PathBuf, String> {
+    debug!("searching for apx projects in {}", root.display());
+
+    let mut found: Vec<PathBuf> = Vec::new();
+
+    for entry in WalkDir::new(root)
+        .min_depth(1)
+        .max_depth(MAX_DISCOVERY_DEPTH + 1)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            !name.starts_with('.') && name != "node_modules" && name != "__pycache__"
+        })
+        .flatten()
+    {
+        if entry.file_type().is_file() && entry.file_name() == "pyproject.toml" {
+            let depth = entry.depth();
+            debug!(
+                "checking pyproject.toml at depth {}: {}",
+                depth,
+                entry.path().display()
+            );
+            if has_apx_config(entry.path())
+                && let Some(parent) = entry.path().parent()
+            {
+                found.push(parent.to_path_buf());
+            }
+        }
+    }
+
+    match found.len() {
+        0 => Err("apx folder not found".to_string()),
+        1 => {
+            debug!("discovered apx project at {}", found[0].display());
+            Ok(found.remove(0))
+        }
+        _ => {
+            let paths = found
+                .iter()
+                .map(|p| format!("- {}", p.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(format!(
+                "apx application identified in several sub-folders, \
+                 please explicitly specify the one you would like to use:\n{paths}"
+            ))
+        }
+    }
+}
+
+/// Check whether a `pyproject.toml` file contains a `[tool.apx]` section.
+pub(crate) fn has_apx_config(pyproject_path: &Path) -> bool {
+    fs::read_to_string(pyproject_path)
+        .ok()
+        .and_then(|s| s.parse::<toml::Value>().ok())
+        .and_then(|v| v.get("tool")?.get("apx").cloned())
+        .is_some()
+}
+
+/// Read, mutate, and write back a `pyproject.toml` via `toml_edit`.
+pub(crate) fn modify_pyproject(
+    path: &Path,
+    f: impl FnOnce(&mut DocumentMut) -> Result<(), String>,
+) -> Result<(), String> {
+    let contents =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read pyproject.toml: {e}"))?;
+    let mut doc = contents
+        .parse::<DocumentMut>()
+        .map_err(|e| format!("Invalid TOML: {e}"))?;
+    f(&mut doc)?;
+    fs::write(path, doc.to_string()).map_err(|e| format!("Failed to write pyproject.toml: {e}"))?;
+    Ok(())
 }
 
 /// Project template types
@@ -75,5 +178,154 @@ impl Layout {
             Layout::Basic => None,
             Layout::Sidebar => Some("sidebar"),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const APX_PYPROJECT: &str = r#"[project]
+name = "my-app"
+
+[tool.apx.metadata]
+app-name = "my-app"
+"#;
+
+    const PLAIN_PYPROJECT: &str = r#"[project]
+name = "other-project"
+version = "0.1.0"
+"#;
+
+    #[test]
+    fn test_has_apx_config_true() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("pyproject.toml");
+        fs::write(&path, APX_PYPROJECT).unwrap();
+        assert!(has_apx_config(&path));
+    }
+
+    #[test]
+    fn test_has_apx_config_false() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("pyproject.toml");
+        fs::write(&path, PLAIN_PYPROJECT).unwrap();
+        assert!(!has_apx_config(&path));
+    }
+
+    #[test]
+    fn test_has_apx_config_missing_file() {
+        let dir = TempDir::new().unwrap();
+        assert!(!has_apx_config(&dir.path().join("pyproject.toml")));
+    }
+
+    #[test]
+    fn test_discover_finds_single_apx_project() {
+        let root = TempDir::new().unwrap();
+        let pkg = root.path().join("packages").join("app");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(pkg.join("pyproject.toml"), APX_PYPROJECT).unwrap();
+
+        let result = discover_apx_project(root.path()).unwrap();
+        assert_eq!(result, pkg);
+    }
+
+    #[test]
+    fn test_discover_errors_on_multiple_projects() {
+        let root = TempDir::new().unwrap();
+
+        let pkg1 = root.path().join("packages").join("app1");
+        fs::create_dir_all(&pkg1).unwrap();
+        fs::write(pkg1.join("pyproject.toml"), APX_PYPROJECT).unwrap();
+
+        let pkg2 = root.path().join("packages").join("app2");
+        fs::create_dir_all(&pkg2).unwrap();
+        fs::write(pkg2.join("pyproject.toml"), APX_PYPROJECT).unwrap();
+
+        let err = discover_apx_project(root.path()).unwrap_err();
+        assert!(err.contains("several sub-folders"), "got: {err}");
+        assert!(err.contains("app1"), "got: {err}");
+        assert!(err.contains("app2"), "got: {err}");
+    }
+
+    #[test]
+    fn test_discover_errors_when_none_found() {
+        let root = TempDir::new().unwrap();
+        // Empty directory -- no apx projects
+        let err = discover_apx_project(root.path()).unwrap_err();
+        assert!(err.contains("apx folder not found"), "got: {err}");
+    }
+
+    #[test]
+    fn test_discover_ignores_non_apx_pyproject() {
+        let root = TempDir::new().unwrap();
+        let pkg = root.path().join("packages").join("lib");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(pkg.join("pyproject.toml"), PLAIN_PYPROJECT).unwrap();
+
+        let err = discover_apx_project(root.path()).unwrap_err();
+        assert!(err.contains("apx folder not found"), "got: {err}");
+    }
+
+    #[test]
+    fn test_discover_respects_max_depth() {
+        let root = TempDir::new().unwrap();
+        // 6 directory levels deep -- exceeds MAX_DISCOVERY_DEPTH (5), should NOT be found
+        let deep = root.path().join("a/b/c/d/e/f");
+        fs::create_dir_all(&deep).unwrap();
+        fs::write(deep.join("pyproject.toml"), APX_PYPROJECT).unwrap();
+
+        let err = discover_apx_project(root.path()).unwrap_err();
+        assert!(err.contains("apx folder not found"), "got: {err}");
+    }
+
+    #[test]
+    fn test_discover_finds_at_max_depth() {
+        let root = TempDir::new().unwrap();
+        // Depth 5: a/b/c/d/e/pyproject.toml -- should be found
+        let deep = root.path().join("a/b/c/d/e");
+        fs::create_dir_all(&deep).unwrap();
+        fs::write(deep.join("pyproject.toml"), APX_PYPROJECT).unwrap();
+
+        let result = discover_apx_project(root.path()).unwrap();
+        assert_eq!(result, deep);
+    }
+
+    #[test]
+    fn test_discover_skips_hidden_dirs() {
+        let root = TempDir::new().unwrap();
+        let hidden = root.path().join(".hidden").join("app");
+        fs::create_dir_all(&hidden).unwrap();
+        fs::write(hidden.join("pyproject.toml"), APX_PYPROJECT).unwrap();
+
+        let err = discover_apx_project(root.path()).unwrap_err();
+        assert!(err.contains("apx folder not found"), "got: {err}");
+    }
+
+    #[test]
+    fn test_find_app_dir_explicit_path_skips_discovery() {
+        let explicit = PathBuf::from("/some/explicit/path");
+        let result = find_app_dir(Some(explicit.clone())).unwrap();
+        assert_eq!(result, explicit);
+    }
+
+    #[test]
+    fn test_modify_pyproject_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("pyproject.toml");
+        fs::write(&path, PLAIN_PYPROJECT).unwrap();
+
+        modify_pyproject(&path, |doc| {
+            doc["tool"]["custom"] = toml_edit::Item::Value("hello".into());
+            Ok(())
+        })
+        .unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("[project]"));
+        assert!(content.contains("name = \"other-project\""));
+        assert!(content.contains("custom = \"hello\""));
     }
 }

--- a/crates/cli/src/components/add.rs
+++ b/crates/cli/src/components/add.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::common::{format_elapsed_ms, read_project_metadata, spinner};
 
@@ -76,7 +76,7 @@ pub async fn run(args: ComponentsAddArgs) -> i32 {
 /// CLI handler for the `add` command. Uses the API and handles console output.
 pub async fn run_inner(args: ComponentsAddArgs) -> Result<(), String> {
     let start_time = Instant::now();
-    let app_dir = resolve_app_dir(args.app_path.clone());
+    let app_dir = find_app_dir(args.app_path.clone())?;
 
     // Handle dry-run separately since API doesn't support it
     if args.dry_run {

--- a/crates/cli/src/dev/apply.rs
+++ b/crates/cli/src/dev/apply.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use tera::Context;
 use walkdir::WalkDir;
 
-use crate::common::{Assistant, Layout, Template, resolve_app_dir};
+use crate::common::{Assistant, Layout, Template, find_app_dir};
 use crate::run_cli_async_helper;
 use apx_core::interop::extract_templates;
 
@@ -148,7 +148,7 @@ impl FileChange {
 }
 
 async fn run_inner(args: ApplyArgs) -> Result<(), String> {
-    let app_dir = resolve_app_dir(args.app_path);
+    let app_dir = find_app_dir(args.app_path)?;
 
     // Read project context
     let (app_name, app_slug) = read_project_context(&app_dir)?;

--- a/crates/cli/src/dev/check.rs
+++ b/crates/cli/src/dev/check.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use std::path::PathBuf;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::common::OutputMode;
 use apx_core::ops::check::run_check;
@@ -20,7 +20,7 @@ pub async fn run(args: CheckArgs) -> i32 {
 }
 
 async fn run_inner(args: CheckArgs) -> Result<(), String> {
-    let app_dir = resolve_app_dir(args.app_path);
+    let app_dir = find_app_dir(args.app_path)?;
 
     run_check(&app_dir, OutputMode::Interactive).await
 }

--- a/crates/cli/src/dev/logs.rs
+++ b/crates/cli/src/dev/logs.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tracing::debug;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_common::{LogAggregator, should_skip_log};
 use apx_core::dev::common::{lock_path, read_lock};
@@ -41,7 +41,7 @@ pub async fn run(args: LogsArgs) -> i32 {
 }
 
 async fn run_async(args: LogsArgs) -> Result<(), String> {
-    let app_dir = resolve_app_dir(args.app_path.clone());
+    let app_dir = find_app_dir(args.app_path.clone())?;
 
     // Canonicalize path for matching
     let app_path_canonical = app_dir

--- a/crates/cli/src/dev/restart.rs
+++ b/crates/cli/src/dev/restart.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use std::path::PathBuf;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::common::OutputMode;
 use apx_core::ops::dev::restart_dev_server;
@@ -20,7 +20,7 @@ pub async fn run(args: RestartArgs) -> i32 {
 }
 
 async fn run_inner(args: RestartArgs) -> Result<(), String> {
-    let app_dir = resolve_app_dir(args.app_path);
+    let app_dir = find_app_dir(args.app_path)?;
 
     restart_dev_server(&app_dir, OutputMode::Interactive).await?;
     Ok(())

--- a/crates/cli/src/dev/start.rs
+++ b/crates/cli/src/dev/start.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use std::path::PathBuf;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::common::OutputMode;
 use apx_core::ops::dev::stop_dev_server;
@@ -46,13 +46,13 @@ pub async fn run(args: StartArgs) -> i32 {
 }
 
 async fn run_detached(args: StartArgs) -> Result<(), String> {
-    let app_dir = resolve_app_dir(args.app_path);
+    let app_dir = find_app_dir(args.app_path)?;
     let _ = start_dev_server(&app_dir, OutputMode::Interactive).await?;
     Ok(())
 }
 
 async fn run_attached(args: StartArgs) -> Result<(), String> {
-    let app_dir = resolve_app_dir(args.app_path);
+    let app_dir = find_app_dir(args.app_path)?;
 
     let _port = spawn_server(
         &app_dir,

--- a/crates/cli/src/dev/status.rs
+++ b/crates/cli/src/dev/status.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use std::path::PathBuf;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::dev::client::status as get_status;
 use apx_core::dev::common::{lock_path, read_lock};
@@ -21,7 +21,7 @@ pub async fn run(args: StatusArgs) -> i32 {
 }
 
 async fn run_inner(args: StatusArgs) -> Result<(), String> {
-    let app_dir = resolve_app_dir(args.app_path);
+    let app_dir = find_app_dir(args.app_path)?;
 
     let lock_path = lock_path(&app_dir);
     debug!(path = %lock_path.display(), "Checking for dev server lockfile.");

--- a/crates/cli/src/dev/stop.rs
+++ b/crates/cli/src/dev/stop.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use std::path::PathBuf;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::common::OutputMode;
 use apx_core::ops::dev::stop_dev_server;
@@ -20,7 +20,7 @@ pub async fn run(args: StopArgs) -> i32 {
 }
 
 async fn run_inner(args: StopArgs) -> Result<(), String> {
-    let app_dir = resolve_app_dir(args.app_path);
+    let app_dir = find_app_dir(args.app_path)?;
 
     stop_dev_server(&app_dir, OutputMode::Interactive).await?;
     Ok(())

--- a/crates/cli/src/frontend/build.rs
+++ b/crates/cli/src/frontend/build.rs
@@ -3,7 +3,7 @@ use indicatif::ProgressBar;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::common::{
     BunCommand, ensure_entrypoint_deps, format_elapsed_ms, run_command_streaming_with_output,
@@ -26,7 +26,7 @@ pub async fn run(args: BuildArgs) -> i32 {
 }
 
 async fn run_inner(args: BuildArgs) -> Result<(), String> {
-    let app_path = resolve_app_dir(args.app_path);
+    let app_path = find_app_dir(args.app_path)?;
 
     // Run preflight checks (installs deps if needed)
     run_preflight_checks(&app_path).await?;

--- a/crates/cli/src/frontend/dev.rs
+++ b/crates/cli/src/frontend/dev.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use tokio::process::Child;
 use tracing::debug;
 
-use crate::common::resolve_app_dir;
+use crate::common::find_app_dir;
 use crate::run_cli_async_helper;
 use apx_core::common::{
     BunCommand, ensure_entrypoint_deps, read_project_metadata, write_metadata_file,
@@ -49,7 +49,7 @@ async fn run_inner(args: DevArgs) -> Result<(), String> {
         ));
     }
 
-    let app_path = resolve_app_dir(args.app_path);
+    let app_path = find_app_dir(args.app_path)?;
 
     let mut child = run_dev(&app_path).await?;
 

--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -9,7 +9,9 @@ use tokio::process::Command;
 use tracing::debug;
 use walkdir::WalkDir;
 
-use crate::common::{Assistant, Layout, Template, resolve_app_dir};
+use crate::common::{
+    Assistant, Layout, Template, has_apx_config, modify_pyproject, resolve_app_dir,
+};
 use crate::components::add::{ComponentInput, add_components};
 use crate::run_cli_async_helper;
 use apx_core::common::list_profiles;
@@ -62,6 +64,14 @@ pub struct InitArgs {
         help = "The layout to use. Will prompt if not provided"
     )]
     pub layout: Option<Layout>,
+    #[arg(
+        long = "as-member",
+        value_name = "MEMBER_PATH",
+        num_args = 0..=1,
+        default_missing_value = "packages/app",
+        help = "Initialize as a uv workspace member. Defaults to packages/app"
+    )]
+    pub as_member: Option<PathBuf>,
 }
 
 pub async fn run(args: InitArgs) -> i32 {
@@ -73,7 +83,32 @@ async fn run_inner(mut args: InitArgs) -> Result<(), String> {
     let _uv = apx_core::download::resolve_uv().await?;
     let _bun = BunCommand::new().await?;
 
-    let app_path = resolve_app_dir(args.app_path.take());
+    let workspace_root = resolve_app_dir(args.app_path.take());
+
+    // Auto-detect member mode: if CWD has pyproject.toml without [tool.apx],
+    // the user is inside an existing project and we should init as a member.
+    let pyproject_at_root = workspace_root.join("pyproject.toml");
+    if args.as_member.is_none() && pyproject_at_root.exists() && !has_apx_config(&pyproject_at_root)
+    {
+        debug!("Existing pyproject.toml without [tool.apx] detected, switching to member mode");
+        args.as_member = Some(PathBuf::from("packages/app"));
+    }
+
+    let is_member = args.as_member.is_some();
+
+    // Resolve final app_path: for member mode, it's workspace_root/member_path
+    let app_path = if let Some(ref member_path) = args.as_member {
+        let full = workspace_root.join(member_path);
+        debug!(
+            "Member mode: workspace_root={}, app_path={}",
+            workspace_root.display(),
+            full.display()
+        );
+        ensure_workspace_config(&pyproject_at_root, member_path)?;
+        full
+    } else {
+        workspace_root.clone()
+    };
 
     let templates_dir = extract_templates()?;
 
@@ -249,23 +284,27 @@ async fn run_inner(mut args: InitArgs) -> Result<(), String> {
         },
     )?;
 
-    // Git initialization logic
+    // Git initialization logic (always operates at the workspace root)
+    let git_dir = if is_member {
+        &workspace_root
+    } else {
+        &app_path
+    };
     if !is_command_available("git").await {
         println!("⚠️  Git is not available - skipping git initialization");
-    } else if is_in_git_repo(&app_path).await? {
+    } else if is_in_git_repo(git_dir).await? {
         println!("✓ Already in a git repository - skipping git initialization");
     } else {
-        // Try to initialize git repository
         let git_result = run_with_spinner_async(
             "🔧 Initializing git repository...",
             "✅ Git repository initialized",
             || async {
                 let mut init_cmd = Command::new("git");
-                init_cmd.arg("init").current_dir(&app_path);
+                init_cmd.arg("init").current_dir(git_dir);
                 run_command(&mut init_cmd, "Failed to initialize git repository").await?;
 
                 let mut add_cmd = Command::new("git");
-                add_cmd.arg("add").arg(".").current_dir(&app_path);
+                add_cmd.arg("add").arg(".").current_dir(git_dir);
                 run_command(&mut add_cmd, "Failed to add files to git repository").await?;
 
                 let mut commit_cmd = Command::new("git");
@@ -273,14 +312,13 @@ async fn run_inner(mut args: InitArgs) -> Result<(), String> {
                     .arg("commit")
                     .arg("-m")
                     .arg("init")
-                    .current_dir(&app_path);
+                    .current_dir(git_dir);
                 run_command(&mut commit_cmd, "Failed to commit files to git repository").await?;
                 Ok(())
             },
         )
         .await;
 
-        // If git initialization failed, warn but continue
         if let Err(err) = git_result {
             println!("⚠️  Git initialization failed: {err}");
             println!("   Continuing with project setup...");
@@ -372,10 +410,16 @@ async fn run_inner(mut args: InitArgs) -> Result<(), String> {
 
     println!();
     println!("✨ Project {app_name} initialized successfully!");
-    let canonical_path = app_path.canonicalize().unwrap_or_else(|_| app_path.clone());
+    let run_from = if is_member {
+        workspace_root
+            .canonicalize()
+            .unwrap_or_else(|_| workspace_root.clone())
+    } else {
+        app_path.canonicalize().unwrap_or_else(|_| app_path.clone())
+    };
     println!(
         "🚀 Run `cd {} && apx dev start` to get started!",
-        canonical_path.display()
+        run_from.display()
     );
     println!("   (Dependencies will be installed automatically on first run)");
     Ok(())
@@ -533,75 +577,115 @@ async fn run_command(cmd: &mut Command, error_msg: &str) -> Result<(), String> {
     Err(message)
 }
 
-use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Table, Value};
+use toml_edit::{Array, ArrayOfTables, Item, Table, Value};
 
 /// Configure pyproject.toml for standard apx installation from index.
 /// Adds [[tool.uv.index]] for apx-index, [tool.uv.sources].apx pointing to that index,
 /// and "apx=={version}" to [dependency-groups].dev.
 pub fn ensure_apx_uv_config(pyproject: &Path, version: &str) -> Result<(), String> {
-    let contents =
-        fs::read_to_string(pyproject).map_err(|e| format!("Failed to read pyproject.toml: {e}"))?;
+    modify_pyproject(pyproject, |doc| {
+        let tool = doc["tool"].or_insert(Item::Table(Table::new()));
+        let uv = tool["uv"].or_insert(Item::Table(Table::new()));
 
-    let mut doc = contents
-        .parse::<DocumentMut>()
-        .map_err(|e| format!("Invalid TOML: {e}"))?;
+        // --- [[tool.uv.index]] ---
+        let indexes = uv["index"].or_insert(Item::ArrayOfTables(ArrayOfTables::new()));
+        let indexes = indexes
+            .as_array_of_tables_mut()
+            .ok_or("tool.uv.index is not an array")?;
 
-    // --- [[tool.uv.index]] ---
-    let tool = doc["tool"].or_insert(Item::Table(Table::new()));
-    let uv = tool["uv"].or_insert(Item::Table(Table::new()));
+        let exists = indexes
+            .iter()
+            .any(|tbl| tbl.get("name").and_then(|v| v.as_str()) == Some("apx-index"));
 
-    let indexes = uv["index"].or_insert(Item::ArrayOfTables(ArrayOfTables::new()));
-    let indexes = indexes
-        .as_array_of_tables_mut()
-        .ok_or("tool.uv.index is not an array")?;
+        if !exists {
+            let mut tbl = Table::new();
+            tbl["name"] = "apx-index".into();
+            tbl["url"] = APX_INDEX_URL.into();
+            indexes.push(tbl);
+        }
 
-    let exists = indexes
-        .iter()
-        .any(|tbl| tbl.get("name").and_then(|v| v.as_str()) == Some("apx-index"));
+        // --- [tool.uv.sources] ---
+        let sources = uv["sources"].or_insert(Item::Table(Table::new()));
+        let sources = sources
+            .as_table_mut()
+            .ok_or("tool.uv.sources is not a table")?;
 
-    if !exists {
-        let mut tbl = Table::new();
-        tbl["name"] = "apx-index".into();
-        tbl["url"] = APX_INDEX_URL.into();
-        indexes.push(tbl);
+        if !sources.contains_key("apx") {
+            let mut apx_src = Table::new();
+            apx_src["index"] = "apx-index".into();
+            sources["apx"] = Item::Table(apx_src);
+        }
+
+        // --- [dependency-groups].dev ---
+        let dep_groups = doc["dependency-groups"].or_insert(Item::Table(Table::new()));
+        let dep_groups = dep_groups
+            .as_table_mut()
+            .ok_or("dependency-groups is not a table")?;
+
+        let dev_deps = dep_groups["dev"].or_insert(Item::Value(Value::Array(Array::new())));
+        let dev_array = dev_deps
+            .as_array_mut()
+            .ok_or("dependency-groups.dev is not an array")?;
+
+        let apx_exists = dev_array
+            .iter()
+            .any(|v| v.as_str().map(|s| s.starts_with("apx")).unwrap_or(false));
+        if !apx_exists {
+            let apx_spec = format!("apx=={version}");
+            dev_array.push(apx_spec.as_str());
+        }
+
+        Ok(())
+    })
+}
+
+/// Add or update `[tool.uv.workspace]` in a root `pyproject.toml`.
+///
+/// Derives a glob pattern from the member path (e.g. `packages/app` -> `packages/*`)
+/// and ensures it's present in the `members` array. Creates the root `pyproject.toml`
+/// if it doesn't exist.
+fn ensure_workspace_config(root_pyproject: &Path, member_path: &Path) -> Result<(), String> {
+    let member_str = member_path.to_string_lossy().replace('\\', "/");
+    let member_glob = match member_str.rsplit_once('/') {
+        Some((parent, _)) => format!("{parent}/*"),
+        None => member_str.to_string(),
+    };
+
+    if !root_pyproject.exists() {
+        let minimal = format!(
+            "[project]\nname = \"workspace\"\nversion = \"0.0.0\"\n\n\
+             [tool.uv.workspace]\nmembers = [\"{member_glob}\"]\n"
+        );
+        fs::write(root_pyproject, minimal)
+            .map_err(|e| format!("Failed to create root pyproject.toml: {e}"))?;
+        debug!("Created root pyproject.toml with workspace config");
+        return Ok(());
     }
 
-    // --- [tool.uv.sources] ---
-    let sources = uv["sources"].or_insert(Item::Table(Table::new()));
-    let sources = sources
-        .as_table_mut()
-        .ok_or("tool.uv.sources is not a table")?;
+    modify_pyproject(root_pyproject, |doc| {
+        let tool = doc["tool"].or_insert(Item::Table(Table::new()));
+        let uv = tool["uv"].or_insert(Item::Table(Table::new()));
+        let workspace = uv["workspace"].or_insert(Item::Table(Table::new()));
+        let workspace = workspace
+            .as_table_mut()
+            .ok_or("tool.uv.workspace is not a table")?;
 
-    if !sources.contains_key("apx") {
-        let mut apx = Table::new();
-        apx["index"] = "apx-index".into();
-        sources["apx"] = Item::Table(apx);
-    }
+        let members = workspace["members"].or_insert(Item::Value(Value::Array(Array::new())));
+        let members = members
+            .as_array_mut()
+            .ok_or("tool.uv.workspace.members is not an array")?;
 
-    // --- [dependency-groups].dev ---
-    let dep_groups = doc["dependency-groups"].or_insert(Item::Table(Table::new()));
-    let dep_groups = dep_groups
-        .as_table_mut()
-        .ok_or("dependency-groups is not a table")?;
+        let already_present = members
+            .iter()
+            .any(|v| v.as_str() == Some(member_glob.as_str()));
 
-    let dev_deps = dep_groups["dev"].or_insert(Item::Value(Value::Array(Array::new())));
-    let dev_array = dev_deps
-        .as_array_mut()
-        .ok_or("dependency-groups.dev is not an array")?;
+        if !already_present {
+            members.push(member_glob.as_str());
+            debug!("Added workspace member glob: {member_glob}");
+        }
 
-    // Add "apx=={version}" if not present (check for any apx entry)
-    let apx_exists = dev_array
-        .iter()
-        .any(|v| v.as_str().map(|s| s.starts_with("apx")).unwrap_or(false));
-    if !apx_exists {
-        let apx_spec = format!("apx=={version}");
-        dev_array.push(apx_spec.as_str());
-    }
-
-    fs::write(pyproject, doc.to_string())
-        .map_err(|e| format!("Failed to write pyproject.toml: {e}"))?;
-
-    Ok(())
+        Ok(())
+    })
 }
 
 async fn is_command_available(cmd: &str) -> bool {
@@ -693,5 +777,72 @@ dev = [
         assert!(normalize_app_name("my@app").is_err());
         assert!(normalize_app_name("my/app").is_err());
         assert!(normalize_app_name("my.app").is_err());
+    }
+
+    #[test]
+    fn test_ensure_workspace_config_creates_new_file() {
+        let dir = TempDir::new().unwrap();
+        let pyproject = dir.path().join("pyproject.toml");
+
+        ensure_workspace_config(&pyproject, Path::new("packages/app")).unwrap();
+
+        let content = fs::read_to_string(&pyproject).unwrap();
+        assert!(content.contains("[tool.uv.workspace]"));
+        assert!(content.contains("packages/*"));
+    }
+
+    #[test]
+    fn test_ensure_workspace_config_adds_to_existing() {
+        let dir = TempDir::new().unwrap();
+        let pyproject = create_test_pyproject(dir.path());
+
+        ensure_workspace_config(&pyproject, Path::new("packages/app")).unwrap();
+
+        let content = fs::read_to_string(&pyproject).unwrap();
+        assert!(content.contains("[project]"));
+        assert!(content.contains("name = \"test-app\""));
+        assert!(content.contains("packages/*"));
+    }
+
+    #[test]
+    fn test_ensure_workspace_config_appends_member() {
+        let dir = TempDir::new().unwrap();
+        let pyproject = dir.path().join("pyproject.toml");
+        let initial = r#"[project]
+name = "workspace"
+
+[tool.uv.workspace]
+members = ["libs/*"]
+"#;
+        fs::write(&pyproject, initial).unwrap();
+
+        ensure_workspace_config(&pyproject, Path::new("packages/app")).unwrap();
+
+        let content = fs::read_to_string(&pyproject).unwrap();
+        assert!(content.contains("libs/*"));
+        assert!(content.contains("packages/*"));
+    }
+
+    #[test]
+    fn test_ensure_workspace_config_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let pyproject = create_test_pyproject(dir.path());
+
+        ensure_workspace_config(&pyproject, Path::new("packages/app")).unwrap();
+        ensure_workspace_config(&pyproject, Path::new("packages/app")).unwrap();
+
+        let content = fs::read_to_string(&pyproject).unwrap();
+        assert_eq!(content.matches("packages/*").count(), 1);
+    }
+
+    #[test]
+    fn test_ensure_workspace_config_derives_glob() {
+        let dir = TempDir::new().unwrap();
+        let pyproject = dir.path().join("pyproject.toml");
+
+        ensure_workspace_config(&pyproject, Path::new("src/apps/my-app")).unwrap();
+
+        let content = fs::read_to_string(&pyproject).unwrap();
+        assert!(content.contains("src/apps/*"), "content: {content}");
     }
 }


### PR DESCRIPTION
## Summary

Implements [#90](https://github.com/databricks-solutions/apx/issues/90) — make apx composable via uv workspaces.

- Add `apx init --as-member [MEMBER_PATH]` flag (defaults to `packages/app`) to scaffold an app as a uv workspace member
- Auto-detect member mode when `apx init` runs in a directory with an existing `pyproject.toml` without `[tool.apx]`
- Add `find_app_dir` with automatic project discovery (scans subdirectories up to 5 levels deep) so all commands (`dev start`, `build`, `check`, etc.) work from the workspace root
- Add shared `modify_pyproject` helper to eliminate TOML read/parse/write duplication between `ensure_apx_uv_config` and `ensure_workspace_config`
- 25 unit tests covering discovery, workspace config, depth limits, idempotency

### Changes

| File | What |
|------|------|
| `crates/cli/src/common.rs` | `find_app_dir`, `discover_apx_project`, `has_apx_config`, `modify_pyproject` + 12 tests |
| `crates/cli/src/init.rs` | `--as-member` flag, auto-detection, `ensure_workspace_config`, refactored `ensure_apx_uv_config` + 5 tests |
| 11 command files | Switch from `resolve_app_dir` to `find_app_dir` (one-line change each) |

Zero changes to `crates/core` — all new logic is self-contained in CLI.

Closes #90

## Test plan

- [x] `cargo test -p apx-cli` — 25 tests pass
- [x] `cargo clippy -p apx-cli` — clean
- [x] `just check` — all checks pass (ruff, prettier, cargo check, clippy, fmt, ty)
- [x] `cargo test --workspace --exclude apx-studio` — full suite passes
- [x] Manual: `apx init --as-member` in empty dir creates workspace layout
- [x] Manual: `apx init` in dir with existing `pyproject.toml` auto-detects member mode
- [x] Manual: `apx dev check` from workspace root discovers nested app


Made with [Cursor](https://cursor.com)