### PR TITLE
Enrich MCP context for AI agents

### DIFF
--- a/crates/mcp/src/info_content.rs
+++ b/crates/mcp/src/info_content.rs
@@ -8,8 +8,131 @@ apx bundles together a set of tools and libraries to help you with the complete 
 - **Frontend**: React + TypeScript + shadcn/ui
 - **Build Tools**: uv (Python), bun (JavaScript/TypeScript)
 
+## Project Structure
+
+```
+<project_root>/
+├── pyproject.toml          # Python project config (app name, slug, entrypoint, api_prefix)
+├── src/<app_slug>/          # Backend Python package
+│   ├── app.py              # FastAPI entrypoint (app = FastAPI(...))
+│   └── routers/            # FastAPI route modules
+├── ui/                     # Frontend React app
+│   ├── src/
+│   │   ├── lib/api.ts      # Generated API client (Orval) — DO NOT edit manually
+│   │   ├── lib/selector.ts # Default query selector
+│   │   ├── components/ui/  # Installed shadcn components
+│   │   └── routes/         # Page components (TanStack Router)
+│   └── package.json
+└── databricks.yml          # Databricks deployment config
+```
+
+## Key Frontend Patterns
+
+### Query with Suspense (recommended)
+```tsx
+import { Suspense } from "react";
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
+import { ErrorBoundary } from "react-error-boundary";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useListItemsSuspense } from "@/lib/api";
+import selector from "@/lib/selector";
+
+function ItemsContent() {
+  const { data } = useListItemsSuspense(selector());
+  return <div>{/* render data */}</div>;
+}
+
+export function ItemsPage() {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary onReset={reset} fallbackRender={({ resetErrorBoundary }) => (
+          <div>
+            <p>Something went wrong</p>
+            <button onClick={resetErrorBoundary}>Try again</button>
+          </div>
+        )}>
+          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+            <ItemsContent />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+}
+```
+
+### Mutation with cache invalidation
+```tsx
+import { useCreateItem } from "@/lib/api";
+import { useQueryClient } from "@tanstack/react-query";
+
+function CreateItemButton() {
+  const queryClient = useQueryClient();
+  const { mutate, isPending } = useCreateItem({
+    mutation: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["listItems"] });
+      },
+    },
+  });
+
+  return (
+    <button onClick={() => mutate({ data: { name: "New item" } })} disabled={isPending}>
+      {isPending ? "Creating..." : "Create"}
+    </button>
+  );
+}
+```
+
+### selector() usage
+- No params: `useListItemsSuspense(selector())`
+- With params: `useListItemsSuspense({ params: { page, page_size }, ...selector() })`
+
+## Key Backend Patterns
+
+### FastAPI router with operation_id
+```python
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api")
+
+@router.get("/items", operation_id="listItems")
+async def list_items(page: int = 1, page_size: int = 20):
+    ...
+
+@router.post("/items", operation_id="createItem")
+async def create_item(item: ItemCreate):
+    ...
+```
+
+The `operation_id` is used to generate TypeScript hooks (e.g., `useListItems`, `useCreateItem`).
+
+## Workflow
+
+1. **routes** — List all API routes to understand the project's API surface
+2. **get_route_info** — Get a complete code example for a specific route
+3. **search_registry_components** / **add_component** — Find and install UI components
+4. **refresh_openapi** — Regenerate the API client after backend route changes
+5. **check** — Run type checks to verify correctness
+6. **start** / **restart** — Start or restart the dev server to test changes
+7. **logs** — Diagnose runtime errors if something goes wrong
+
 ## Tool Usage
 
 All project-scoped tools require an `app_path` parameter — the absolute path to the project directory.
 Global tools (like `docs`) do not require `app_path`.
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_content_contains_key_sections() {
+        assert!(APX_INFO_CONTENT.contains("Project Structure"));
+        assert!(APX_INFO_CONTENT.contains("Frontend Patterns"));
+        assert!(APX_INFO_CONTENT.contains("Backend Patterns"));
+        assert!(APX_INFO_CONTENT.contains("Workflow"));
+    }
+}

--- a/crates/mcp/src/resources.rs
+++ b/crates/mcp/src/resources.rs
@@ -1,10 +1,28 @@
 use crate::info_content::APX_INFO_CONTENT;
+use crate::tools::project::parse_openapi_operations;
+use crate::validation::validate_app_path;
 use rmcp::model::*;
+use serde::Serialize;
 
 pub fn list_resources() -> Vec<Resource> {
     let mut raw = RawResource::new("apx://info", "apx-info".to_string());
     raw.description = Some("Information about apx toolkit".to_string());
     raw.mime_type = Some("text/plain".to_string());
+    vec![raw.no_annotation()]
+}
+
+pub fn list_resource_templates() -> Vec<ResourceTemplate> {
+    let raw = RawResourceTemplate {
+        uri_template: "apx://project/{app_path}".to_string(),
+        name: "project-context".to_string(),
+        title: Some("Project Context".to_string()),
+        description: Some(
+            "Comprehensive project context including routes, schemas, and installed UI components."
+                .to_string(),
+        ),
+        mime_type: Some("application/json".to_string()),
+        icons: None,
+    };
     vec![raw.no_annotation()]
 }
 
@@ -14,5 +32,135 @@ pub fn read_resource(uri: &str) -> Result<ReadResourceResult, String> {
             contents: vec![ResourceContents::text(APX_INFO_CONTENT, uri)],
         }),
         _ => Err(format!("Resource not found: {uri}")),
+    }
+}
+
+#[derive(Serialize)]
+struct RouteSummary {
+    id: String,
+    method: String,
+    path: String,
+    hook_name: String,
+}
+
+#[derive(Serialize)]
+struct ProjectContext {
+    app_name: String,
+    app_slug: String,
+    api_prefix: String,
+    has_ui: bool,
+    routes: Vec<RouteSummary>,
+    ui_components: Vec<String>,
+}
+
+pub async fn read_project_resource(app_path: &str) -> Result<ReadResourceResult, String> {
+    let path = validate_app_path(app_path)?;
+
+    use apx_core::common::read_project_metadata;
+
+    let metadata = read_project_metadata(&path)?;
+
+    // Best-effort: try to generate OpenAPI and parse routes
+    let routes: Vec<RouteSummary> = try_parse_routes(&path, &metadata).await.unwrap_or_default();
+
+    // Scan for installed UI components
+    let ui_components = scan_ui_components(&path);
+
+    let has_ui = metadata.ui_root.is_some();
+    let context = ProjectContext {
+        app_name: metadata.app_name,
+        app_slug: metadata.app_slug,
+        api_prefix: metadata.api_prefix,
+        has_ui,
+        routes,
+        ui_components,
+    };
+
+    let json = serde_json::to_string_pretty(&context)
+        .map_err(|e| format!("Failed to serialize project context: {e}"))?;
+
+    let uri = format!("apx://project/{app_path}");
+    Ok(ReadResourceResult {
+        contents: vec![ResourceContents::text(json, uri)],
+    })
+}
+
+async fn try_parse_routes(
+    path: &std::path::Path,
+    metadata: &apx_core::common::ProjectMetadata,
+) -> Result<Vec<RouteSummary>, String> {
+    use apx_core::interop::generate_openapi_spec;
+
+    let (openapi_content, _) =
+        generate_openapi_spec(path, &metadata.app_entrypoint, &metadata.app_slug).await?;
+
+    let openapi: serde_json::Value =
+        serde_json::from_str(&openapi_content).map_err(|e| format!("Parse error: {e}"))?;
+
+    let route_infos = parse_openapi_operations(&openapi)?;
+
+    Ok(route_infos
+        .into_iter()
+        .map(|r| RouteSummary {
+            id: r.id,
+            method: r.method,
+            path: r.path,
+            hook_name: r.hook_name,
+        })
+        .collect())
+}
+
+fn scan_ui_components(project_root: &std::path::Path) -> Vec<String> {
+    let ui_dir = project_root.join("ui/src/components/ui");
+    let Ok(entries) = std::fs::read_dir(&ui_dir) else {
+        return Vec::new();
+    };
+
+    let mut components: Vec<String> = entries
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let name = entry.file_name().to_string_lossy().to_string();
+            // Include .tsx files, strip extension for component name
+            if name.ends_with(".tsx") {
+                Some(name.trim_end_matches(".tsx").to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    components.sort();
+    components
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_resource_templates_returns_project() {
+        let templates = list_resource_templates();
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].raw.uri_template, "apx://project/{app_path}");
+        assert_eq!(templates[0].raw.name, "project-context");
+    }
+
+    #[test]
+    fn read_project_resource_rejects_relative_path() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(read_project_resource("relative/path"));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("absolute path"), "got: {err}");
+    }
+
+    #[test]
+    fn read_project_resource_rejects_nonexistent() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(read_project_resource("/tmp/__apx_test_nonexistent_proj__"));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("does not exist"), "got: {err}");
     }
 }

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -46,7 +46,7 @@ impl ApxServer {
 
     #[tool(
         name = "start",
-        description = "Start development server and return the URL",
+        description = "Start the development server and return its URL. Call before testing UI or API changes.",
         annotations(destructive_hint = true, read_only_hint = false)
     )]
     async fn start(
@@ -58,7 +58,7 @@ impl ApxServer {
 
     #[tool(
         name = "stop",
-        description = "Stop the development server",
+        description = "Stop the development server.",
         annotations(
             destructive_hint = true,
             read_only_hint = false,
@@ -74,7 +74,7 @@ impl ApxServer {
 
     #[tool(
         name = "restart",
-        description = "Restart the development server (preserves port if possible)",
+        description = "Restart the development server (preserves port). Use after backend code changes.",
         annotations(destructive_hint = true, read_only_hint = false)
     )]
     async fn restart(
@@ -86,7 +86,7 @@ impl ApxServer {
 
     #[tool(
         name = "logs",
-        description = "Fetch recent dev server logs",
+        description = "Fetch recent dev server logs. Use to diagnose runtime errors or startup issues.",
         annotations(read_only_hint = true)
     )]
     async fn logs(
@@ -100,7 +100,7 @@ impl ApxServer {
 
     #[tool(
         name = "check",
-        description = "Check the project code for errors (runs tsc and ty checks in parallel)",
+        description = "Run TypeScript and Python type checks in parallel. Returns categorized errors. Call after making changes to verify correctness.",
         annotations(read_only_hint = true)
     )]
     async fn check(
@@ -112,7 +112,7 @@ impl ApxServer {
 
     #[tool(
         name = "refresh_openapi",
-        description = "Regenerate OpenAPI schema and API client",
+        description = "Regenerate the OpenAPI schema and TypeScript API client from backend routes. Run after adding or modifying backend routes.",
         annotations(
             destructive_hint = true,
             read_only_hint = false,
@@ -128,7 +128,7 @@ impl ApxServer {
 
     #[tool(
         name = "get_route_info",
-        description = "Get code example for using a specific API route",
+        description = "Get a complete frontend code example for a specific API route, including Suspense/ErrorBoundary scaffold and correct hook usage with parameters. Call this before writing any frontend code that uses an API route. Pass the operation_id from the routes tool.",
         annotations(read_only_hint = true)
     )]
     async fn get_route_info(
@@ -140,7 +140,7 @@ impl ApxServer {
 
     #[tool(
         name = "routes",
-        description = "List all API routes from the OpenAPI schema",
+        description = "List all API routes with their parameters, request/response schemas, and generated hook names. Call this first to understand the project's API surface before reading source files.",
         annotations(read_only_hint = true)
     )]
     async fn routes(
@@ -154,7 +154,7 @@ impl ApxServer {
 
     #[tool(
         name = "databricks_apps_logs",
-        description = "Fetch Databricks Apps logs from an already deployed app using the Databricks CLI",
+        description = "Fetch logs from a deployed Databricks App using the Databricks CLI. Use for debugging deployed (not local dev) issues.",
         annotations(read_only_hint = true)
     )]
     async fn databricks_apps_logs(
@@ -168,7 +168,7 @@ impl ApxServer {
 
     #[tool(
         name = "search_registry_components",
-        description = "Search shadcn registry components using semantic search. Supports filtering by category, type, and registry.",
+        description = "Semantic search for UI components across configured registries (shadcn, etc). Returns component IDs usable with add_component.",
         annotations(read_only_hint = true)
     )]
     async fn search_registry_components(
@@ -180,7 +180,7 @@ impl ApxServer {
 
     #[tool(
         name = "add_component",
-        description = "Add a component to the project. Component ID can be 'component-name' (from default registry) or '@registry-name/component-name'.",
+        description = "Install a UI component into the project. Accepts 'component-name' (default registry) or '@registry-name/component-name'.",
         annotations(destructive_hint = true, read_only_hint = false)
     )]
     async fn add_component(
@@ -192,7 +192,7 @@ impl ApxServer {
 
     #[tool(
         name = "list_registry_components",
-        description = "List all available components in a registry. Use default shadcn registry if no registry specified.",
+        description = "List all available components in a registry. Defaults to shadcn registry if none specified.",
         annotations(read_only_hint = true)
     )]
     async fn list_registry_components(
@@ -206,7 +206,7 @@ impl ApxServer {
 
     #[tool(
         name = "docs",
-        description = "Search Databricks SDK documentation for relevant code examples and API references",
+        description = "Search Databricks SDK documentation for Python code examples and API references. Always call this before writing any Databricks SDK (ws.*) call to verify the correct method signature.",
         annotations(read_only_hint = true)
     )]
     async fn docs(
@@ -252,16 +252,35 @@ impl ServerHandler for ApxServer {
         })
     }
 
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, rmcp::ErrorData> {
+        Ok(ListResourceTemplatesResult {
+            resource_templates: crate::resources::list_resource_templates(),
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
         _ctx: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, rmcp::ErrorData> {
-        crate::resources::read_resource(request.uri.as_str()).map_err(|e| {
-            rmcp::ErrorData::resource_not_found(
-                e,
-                Some(serde_json::json!({ "uri": request.uri.as_str() })),
-            )
+        let uri = request.uri.as_str();
+
+        if let Some(app_path) = uri.strip_prefix("apx://project/") {
+            return crate::resources::read_project_resource(app_path)
+                .await
+                .map_err(|e| {
+                    rmcp::ErrorData::resource_not_found(e, Some(serde_json::json!({ "uri": uri })))
+                });
+        }
+
+        crate::resources::read_resource(uri).map_err(|e| {
+            rmcp::ErrorData::resource_not_found(e, Some(serde_json::json!({ "uri": uri })))
         })
     }
 }

--- a/crates/mcp/src/tools/project.rs
+++ b/crates/mcp/src/tools/project.rs
@@ -14,21 +14,146 @@ pub struct GetRouteInfoArgs {
     pub operation_id: String,
 }
 
-#[derive(Serialize)]
-struct RouteInfo {
-    id: String,
-    method: String,
-    path: String,
-    description: String,
+#[derive(Serialize, Clone)]
+pub(crate) struct ParamInfo {
+    name: String,
+    location: String,
+    param_type: String,
+    required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
 }
 
-fn parse_openapi_operations(openapi: &Value) -> Result<Vec<RouteInfo>, String> {
+#[derive(Serialize)]
+pub(crate) struct RouteInfo {
+    pub(crate) id: String,
+    pub(crate) method: String,
+    pub(crate) path: String,
+    pub(crate) description: String,
+    pub(crate) hook_name: String,
+    pub(crate) parameters: Vec<ParamInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) request_body_schema: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) response_schema: Option<Value>,
+}
+
+/// Single-level `$ref` resolution against `#/components/schemas/*`.
+fn resolve_schema_ref<'a>(schema: &'a Value, components: Option<&'a Value>) -> &'a Value {
+    if let Some(ref_str) = schema.get("$ref").and_then(|v| v.as_str())
+        && let Some(schema_name) = ref_str.strip_prefix("#/components/schemas/")
+        && let Some(resolved) = components
+            .and_then(|c| c.get("schemas"))
+            .and_then(|s| s.get(schema_name))
+    {
+        return resolved;
+    }
+    schema
+}
+
+/// Extract parameters from an OpenAPI operation, merging path-level and operation-level params.
+/// Operation-level params take precedence on name+location collision.
+fn extract_parameters(operation: &Value, path_item: &Value) -> Vec<ParamInfo> {
+    let mut params: Vec<ParamInfo> = Vec::new();
+
+    // Collect path-level params first
+    if let Some(path_params) = path_item.get("parameters").and_then(|p| p.as_array()) {
+        for p in path_params {
+            if let Some(info) = parse_single_param(p) {
+                params.push(info);
+            }
+        }
+    }
+
+    // Collect operation-level params, overriding path-level on name+location match
+    if let Some(op_params) = operation.get("parameters").and_then(|p| p.as_array()) {
+        for p in op_params {
+            if let Some(info) = parse_single_param(p) {
+                // Remove any existing param with same name+location
+                params.retain(|existing| {
+                    !(existing.name == info.name && existing.location == info.location)
+                });
+                params.push(info);
+            }
+        }
+    }
+
+    params
+}
+
+fn parse_single_param(param: &Value) -> Option<ParamInfo> {
+    let name = param.get("name").and_then(|v| v.as_str())?.to_string();
+    let location = param
+        .get("in")
+        .and_then(|v| v.as_str())
+        .unwrap_or("query")
+        .to_string();
+    let param_type = param
+        .get("schema")
+        .and_then(|s| s.get("type"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("string")
+        .to_string();
+    let required = param
+        .get("required")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let description = param
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Some(ParamInfo {
+        name,
+        location,
+        param_type,
+        required,
+        description,
+    })
+}
+
+/// Extract request body JSON schema, resolving `$ref` if present.
+fn extract_body_schema(operation: &Value, components: Option<&Value>) -> Option<Value> {
+    let schema = operation
+        .get("requestBody")?
+        .get("content")?
+        .get("application/json")?
+        .get("schema")?;
+
+    Some(resolve_schema_ref(schema, components).clone())
+}
+
+/// Extract response schema from the first 2xx response, resolving `$ref` if present.
+fn extract_response_schema(operation: &Value, components: Option<&Value>) -> Option<Value> {
+    let responses = operation.get("responses")?.as_object()?;
+
+    // Find first 2xx response
+    let response = ["200", "201", "202", "204"]
+        .iter()
+        .find_map(|code| responses.get(*code))?;
+
+    let schema = response
+        .get("content")?
+        .get("application/json")?
+        .get("schema")?;
+
+    Some(resolve_schema_ref(schema, components).clone())
+}
+
+/// Compute the React hook name from an operation ID (e.g., "listItems" → "useListItems").
+fn compute_hook_name(operation_id: &str) -> String {
+    format!("use{}", capitalize_first(operation_id))
+}
+
+pub(crate) fn parse_openapi_operations(openapi: &Value) -> Result<Vec<RouteInfo>, String> {
     let mut routes = Vec::new();
 
     let paths = openapi
         .get("paths")
         .and_then(|p| p.as_object())
         .ok_or_else(|| "OpenAPI schema missing 'paths' object".to_string())?;
+
+    let components = openapi.get("components");
 
     for (path, path_item) in paths {
         let methods_obj = path_item
@@ -61,11 +186,20 @@ fn parse_openapi_operations(openapi: &Value) -> Result<Vec<RouteInfo>, String> {
                 .unwrap_or("")
                 .to_string();
 
+            let hook_name = compute_hook_name(&operation_id);
+            let parameters = extract_parameters(operation, path_item);
+            let request_body_schema = extract_body_schema(operation, components);
+            let response_schema = extract_response_schema(operation, components);
+
             routes.push(RouteInfo {
                 id: operation_id,
                 method: method_upper,
                 path: path.clone(),
                 description,
+                hook_name,
+                parameters,
+                request_body_schema,
+                response_schema,
             });
         }
     }
@@ -81,70 +215,159 @@ fn capitalize_first(s: &str) -> String {
     }
 }
 
-fn generate_query_example(operation_id: &str) -> String {
+fn generate_query_example(
+    operation_id: &str,
+    path: &str,
+    parameters: &[ParamInfo],
+    _response_schema: Option<&Value>,
+) -> String {
     let capitalized = capitalize_first(operation_id);
     let hook_name = format!("use{capitalized}");
     let suspense_hook_name = format!("{hook_name}Suspense");
-    let result_type = format!("{capitalized}QueryResult");
-    let error_type = format!("{capitalized}QueryError");
+
+    // Build hook call args based on parameters
+    let param_names: Vec<&str> = parameters
+        .iter()
+        .filter(|p| p.location == "path" || p.location == "query")
+        .map(|p| p.name.as_str())
+        .collect();
+
+    let hook_call_args = if param_names.is_empty() {
+        "selector()".to_string()
+    } else {
+        let params_obj = param_names.join(", ");
+        format!("{{ params: {{ {params_obj} }}, ...selector() }}")
+    };
+
+    // Build props for component parameters
+    let props_arg = if param_names.is_empty() {
+        String::new()
+    } else {
+        let props: Vec<String> = param_names.iter().map(|n| format!("{n}: string")).collect();
+        format!(
+            "{{ {} }}: {{ {} }}",
+            param_names.join(", "),
+            props.join("; ")
+        )
+    };
+
+    let prop_forwarding = if param_names.is_empty() {
+        String::new()
+    } else {
+        let fwd = param_names
+            .iter()
+            .map(|n| format!("{n}={{{n}}}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!(" {fwd}")
+    };
 
     format!(
-        r#"// Standard query hook
-import {{ {hook_name} }} from "@/lib/api";
-import selector from "@/lib/selector";
+        r#"// === Query: {operation_id} ===
+// Route: GET {path}
+// Hook: {suspense_hook_name} | {hook_name}
 
-const Component = () => {{
-  const {{ data, isLoading, error }} = {hook_name}(selector());
-
-  if (isLoading) return <div>Loading...</div>;
-  if (error) return <div>Error: {{error.message}}</div>;
-
-  return <div>{{/* render data */}}</div>;
-}};
-
-// Suspense query hook (use with React Suspense boundary)
+// --- Suspense variant (recommended) ---
+import {{ Suspense }} from "react";
+import {{ QueryErrorResetBoundary }} from "@tanstack/react-query";
+import {{ ErrorBoundary }} from "react-error-boundary";
+import {{ Skeleton }} from "@/components/ui/skeleton";
 import {{ {suspense_hook_name} }} from "@/lib/api";
 import selector from "@/lib/selector";
 
-const SuspenseComponent = () => {{
-  // No loading/error states needed - handled by Suspense boundary
-  const {{ data }} = {suspense_hook_name}(selector());
+function {capitalized}Content({props_arg}) {{
+  const {{ data }} = {suspense_hook_name}({hook_call_args});
   return <div>{{/* render data */}}</div>;
-}};
+}}
 
-// Usage with Suspense boundary:
-// <Suspense fallback={{<Loading />}}>
-//   <SuspenseComponent />
-// </Suspense>
+export function {capitalized}Page({props_arg}) {{
+  return (
+    <QueryErrorResetBoundary>
+      {{({{ reset }}) => (
+        <ErrorBoundary onReset={{reset}} fallbackRender={{({{ resetErrorBoundary }}) => (
+          <div>
+            <p>Something went wrong</p>
+            <button onClick={{resetErrorBoundary}}>Try again</button>
+          </div>
+        )}}>
+          <Suspense fallback={{<Skeleton className="h-48 w-full" />}}>
+            <{capitalized}Content{prop_forwarding} />
+          </Suspense>
+        </ErrorBoundary>
+      )}}
+    </QueryErrorResetBoundary>
+  );
+}}
 
-// Available types for this query:
-// import type {{ {result_type}, {error_type} }} from "@/lib/api";"#
+// --- Standard variant ---
+// const {{ data, isLoading, error }} = {hook_name}({hook_call_args});"#
     )
 }
 
-fn generate_mutation_example(operation_id: &str) -> String {
+fn generate_mutation_example(
+    operation_id: &str,
+    path: &str,
+    method: &str,
+    parameters: &[ParamInfo],
+    _request_body_schema: Option<&Value>,
+) -> String {
     let capitalized = capitalize_first(operation_id);
     let hook_name = format!("use{capitalized}");
-    let body_type = format!("{capitalized}MutationBody");
-    let result_type = format!("{capitalized}MutationResult");
-    let error_type = format!("{capitalized}MutationError");
+
+    // Derive related query key from path prefix for cache invalidation
+    let related_query_key = derive_related_query_key(path);
+
+    // Build mutate call args
+    let path_params: Vec<&str> = parameters
+        .iter()
+        .filter(|p| p.location == "path")
+        .map(|p| p.name.as_str())
+        .collect();
+
+    let mutate_args = if path_params.is_empty() {
+        "{ data: { /* request body */ } }".to_string()
+    } else {
+        let path_params_obj = path_params.join(", ");
+        format!("{{ params: {{ {path_params_obj} }}, data: {{ /* request body */ }} }}")
+    };
 
     format!(
-        r#"import {{ {hook_name} }} from "@/lib/api";
+        r#"// === Mutation: {operation_id} ===
+// Route: {method} {path}
+// Hook: {hook_name}
 
-const Component = () => {{
-  const {{ mutate, isPending }} = {hook_name}();
+import {{ {hook_name} }} from "@/lib/api";
+import {{ useQueryClient }} from "@tanstack/react-query";
 
-  const handleSubmit = () => {{
-    mutate({{ data: {{ /* request body */ }} }});
-  }};
+function {capitalized}Button() {{
+  const queryClient = useQueryClient();
+  const {{ mutate, isPending }} = {hook_name}({{
+    mutation: {{
+      onSuccess: () => {{
+        queryClient.invalidateQueries({{ queryKey: ["{related_query_key}"] }});
+      }},
+    }},
+  }});
 
-  return <button onClick={{handleSubmit}}>Submit</button>;
-}};
-
-// Available types for this mutation:
-// import type {{ {body_type}, {result_type}, {error_type} }} from "@/lib/api";"#
+  return (
+    <button onClick={{() => mutate({mutate_args})}} disabled={{isPending}}>
+      {{isPending ? "Submitting..." : "Submit"}}
+    </button>
+  );
+}}"#
     )
+}
+
+/// Derive a related query key from a path for cache invalidation.
+/// e.g., "/api/jobs/{id}" → "listJobs", "/api/items" → "listItems"
+fn derive_related_query_key(path: &str) -> String {
+    let segments: Vec<&str> = path
+        .split('/')
+        .filter(|s| !s.is_empty() && !s.starts_with('{'))
+        .collect();
+    // Take the last non-parameter segment as the resource name
+    let resource = segments.last().copied().unwrap_or("items");
+    format!("list{}", capitalize_first(resource))
 }
 
 impl ApxServer {
@@ -248,8 +471,11 @@ impl ApxServer {
             }
         };
 
-        let mut found_method = None;
-        for (_, path_item) in paths {
+        let components = openapi.get("components");
+
+        // Find the operation and capture all context
+        let mut found = None;
+        for (route_path, path_item) in paths {
             if let Some(methods_obj) = path_item.as_object() {
                 for (method, operation) in methods_obj {
                     if let Some(operation_obj) = operation.as_object()
@@ -257,18 +483,28 @@ impl ApxServer {
                             operation_obj.get("operationId").and_then(|v| v.as_str())
                         && op_id == args.operation_id
                     {
-                        found_method = Some(method.to_uppercase());
+                        let method_upper = method.to_uppercase();
+                        let parameters = extract_parameters(operation, path_item);
+                        let body_schema = extract_body_schema(operation, components);
+                        let resp_schema = extract_response_schema(operation, components);
+                        found = Some((
+                            route_path.clone(),
+                            method_upper,
+                            parameters,
+                            body_schema,
+                            resp_schema,
+                        ));
                         break;
                     }
                 }
-                if found_method.is_some() {
+                if found.is_some() {
                     break;
                 }
             }
         }
 
-        let method = match found_method {
-            Some(m) => m,
+        let (route_path, method, parameters, body_schema, resp_schema) = match found {
+            Some(f) => f,
             None => {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
                     "Operation ID '{}' not found in OpenAPI schema",
@@ -278,21 +514,42 @@ impl ApxServer {
         };
 
         let example = if method == "GET" {
-            generate_query_example(&args.operation_id)
+            generate_query_example(
+                &args.operation_id,
+                &route_path,
+                &parameters,
+                resp_schema.as_ref(),
+            )
         } else {
-            generate_mutation_example(&args.operation_id)
+            generate_mutation_example(
+                &args.operation_id,
+                &route_path,
+                &method,
+                &parameters,
+                body_schema.as_ref(),
+            )
         };
 
         #[derive(Serialize)]
         struct RouteInfoResponse {
             operation_id: String,
             method: String,
+            path: String,
+            parameters: Vec<ParamInfo>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            request_body_schema: Option<Value>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            response_schema: Option<Value>,
             example: String,
         }
 
         let response = RouteInfoResponse {
             operation_id: args.operation_id,
             method,
+            path: route_path,
+            parameters,
+            request_body_schema: body_schema,
+            response_schema: resp_schema,
             example,
         };
 
@@ -373,10 +630,13 @@ mod tests {
         let get_route = routes.iter().find(|r| r.method == "GET").unwrap();
         assert_eq!(get_route.id, "listItems");
         assert_eq!(get_route.description, "List all items");
+        assert_eq!(get_route.hook_name, "useListItems");
+        assert!(get_route.parameters.is_empty());
 
         let post_route = routes.iter().find(|r| r.method == "POST").unwrap();
         assert_eq!(post_route.id, "createItem");
         assert_eq!(post_route.description, "Create a new item");
+        assert_eq!(post_route.hook_name, "useCreateItem");
     }
 
     #[test]
@@ -402,5 +662,268 @@ mod tests {
     fn parse_openapi_operations_missing_paths() {
         let openapi = serde_json::json!({});
         assert!(parse_openapi_operations(&openapi).is_err());
+    }
+
+    #[test]
+    fn parse_openapi_extracts_parameters() {
+        let openapi = serde_json::json!({
+            "paths": {
+                "/items/{id}": {
+                    "get": {
+                        "operationId": "getItem",
+                        "summary": "Get item by ID",
+                        "parameters": [
+                            {
+                                "name": "id",
+                                "in": "path",
+                                "required": true,
+                                "schema": { "type": "integer" }
+                            },
+                            {
+                                "name": "page",
+                                "in": "query",
+                                "required": false,
+                                "schema": { "type": "integer" },
+                                "description": "Page number"
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+
+        let routes = parse_openapi_operations(&openapi).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].parameters.len(), 2);
+
+        let id_param = routes[0]
+            .parameters
+            .iter()
+            .find(|p| p.name == "id")
+            .unwrap();
+        assert_eq!(id_param.location, "path");
+        assert_eq!(id_param.param_type, "integer");
+        assert!(id_param.required);
+
+        let page_param = routes[0]
+            .parameters
+            .iter()
+            .find(|p| p.name == "page")
+            .unwrap();
+        assert_eq!(page_param.location, "query");
+        assert!(!page_param.required);
+        assert_eq!(page_param.description.as_deref(), Some("Page number"));
+    }
+
+    #[test]
+    fn parse_openapi_extracts_request_body() {
+        let openapi = serde_json::json!({
+            "paths": {
+                "/items": {
+                    "post": {
+                        "operationId": "createItem",
+                        "summary": "Create item",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": { "type": "string" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let routes = parse_openapi_operations(&openapi).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert!(routes[0].request_body_schema.is_some());
+        let schema = routes[0].request_body_schema.as_ref().unwrap();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["name"].is_object());
+    }
+
+    #[test]
+    fn parse_openapi_extracts_response_schema() {
+        let openapi = serde_json::json!({
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "summary": "List items",
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "array",
+                                            "items": { "type": "object" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let routes = parse_openapi_operations(&openapi).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert!(routes[0].response_schema.is_some());
+        let schema = routes[0].response_schema.as_ref().unwrap();
+        assert_eq!(schema["type"], "array");
+    }
+
+    #[test]
+    fn parse_openapi_resolves_refs() {
+        let openapi = serde_json::json!({
+            "components": {
+                "schemas": {
+                    "Item": {
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "integer" },
+                            "name": { "type": "string" }
+                        }
+                    }
+                }
+            },
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "summary": "List items",
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/Item"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let routes = parse_openapi_operations(&openapi).unwrap();
+        assert_eq!(routes.len(), 1);
+        let schema = routes[0].response_schema.as_ref().unwrap();
+        // $ref should be resolved to the inline schema
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["id"].is_object());
+    }
+
+    #[test]
+    fn parse_openapi_computes_hook_name() {
+        let openapi = serde_json::json!({
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "summary": "List items"
+                    }
+                }
+            }
+        });
+
+        let routes = parse_openapi_operations(&openapi).unwrap();
+        assert_eq!(routes[0].hook_name, "useListItems");
+    }
+
+    #[test]
+    fn parse_openapi_merges_path_and_op_params() {
+        let openapi = serde_json::json!({
+            "paths": {
+                "/items/{id}": {
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "schema": { "type": "string" },
+                            "description": "Path-level ID"
+                        }
+                    ],
+                    "get": {
+                        "operationId": "getItem",
+                        "summary": "Get item",
+                        "parameters": [
+                            {
+                                "name": "id",
+                                "in": "path",
+                                "required": true,
+                                "schema": { "type": "integer" },
+                                "description": "Op-level ID"
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+
+        let routes = parse_openapi_operations(&openapi).unwrap();
+        assert_eq!(routes[0].parameters.len(), 1);
+        // Operation-level param should override path-level
+        assert_eq!(routes[0].parameters[0].param_type, "integer");
+        assert_eq!(
+            routes[0].parameters[0].description.as_deref(),
+            Some("Op-level ID")
+        );
+    }
+
+    #[test]
+    fn generate_query_example_no_params() {
+        let example = generate_query_example("listItems", "/api/items", &[], None);
+        assert!(example.contains("Suspense"));
+        assert!(example.contains("ErrorBoundary"));
+        assert!(example.contains("Skeleton"));
+        assert!(example.contains("selector()"));
+        assert!(example.contains("useListItemsSuspense"));
+    }
+
+    #[test]
+    fn generate_query_example_with_params() {
+        let params = vec![ParamInfo {
+            name: "page".to_string(),
+            location: "query".to_string(),
+            param_type: "integer".to_string(),
+            required: false,
+            description: None,
+        }];
+        let example = generate_query_example("listItems", "/api/items", &params, None);
+        assert!(example.contains("{ params: { page }, ...selector() }"));
+    }
+
+    #[test]
+    fn generate_mutation_example_basic() {
+        let example = generate_mutation_example("createItem", "/api/items", "POST", &[], None);
+        assert!(example.contains("useCreateItem"));
+        assert!(example.contains("onSuccess"));
+        assert!(example.contains("invalidateQueries"));
+        assert!(example.contains("useQueryClient"));
+    }
+
+    #[test]
+    fn generate_mutation_example_with_path_params() {
+        let params = vec![ParamInfo {
+            name: "id".to_string(),
+            location: "path".to_string(),
+            param_type: "integer".to_string(),
+            required: true,
+            description: None,
+        }];
+        let example =
+            generate_mutation_example("updateItem", "/api/items/{id}", "PUT", &params, None);
+        assert!(example.contains("params: { id }"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #94. Reduces the file reads AI agents need (8+) to discover project patterns before writing code.

- **Enrich `routes` tool output** — adds parameters, request/response schemas, hook names, and `$ref` resolution to every route
- **Rewrite `get_route_info` code generation** — produces complete Suspense/ErrorBoundary scaffold with proper hook call args (`selector()` spreading, path params, cache invalidation via `invalidateQueries`)
- **Improve all 12 tool descriptions** — prescriptive, actionable descriptions that tell agents *when* to call each tool
- **Expand `apx://info` resource** — adds project structure, key frontend/backend patterns, and numbered workflow
- **Add `apx://project/{app_path}` resource template** — returns app metadata, enriched routes, and installed UI components as JSON

## Test plan

- [x] `cargo build -p apx-mcp` — no warnings
- [x] `cargo test -p apx-mcp` — 29 tests pass (15 new)
- [x] `cargo clippy -p apx-mcp` — no warnings
- [ ] Manual: start MCP server, call `routes` and `get_route_info` against a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)