### PR TITLE
Improve add_component reliability & MCP context (#109)

### DIFF
--- a/crates/core/src/components/add.rs
+++ b/crates/core/src/components/add.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::common::{BunCommand, read_project_metadata};
@@ -76,6 +76,7 @@ pub struct AddComponentsResult {
     pub written_paths: Vec<PathBuf>,
     pub unchanged_paths: Vec<PathBuf>,
     pub dependencies_installed: Vec<String>,
+    pub auto_detected_deps: Vec<String>,
     pub css_updated_path: Option<String>,
     pub warnings: Vec<String>,
 }
@@ -158,6 +159,20 @@ pub async fn add_components(
         }
     }
 
+    // Auto-detect 3rd-party imports not covered by registry specs
+    let detected_imports = super::detect_external_imports(&all_files);
+    if !detected_imports.is_empty() {
+        // Read package.json to find already-installed deps
+        let existing_deps = read_package_json_deps(app_dir);
+
+        for pkg in &detected_imports {
+            if !existing_deps.contains(pkg) && !all_deps.contains(pkg) {
+                all_deps.insert(pkg.clone());
+                result.auto_detected_deps.push(pkg.clone());
+            }
+        }
+    }
+
     // Install all dependencies at once
     if !all_deps.is_empty() {
         let deps: Vec<String> = all_deps.iter().cloned().collect();
@@ -185,6 +200,32 @@ pub async fn add_components(
     let _ = sync_registry_indexes(app_dir, false).await;
 
     Ok(result)
+}
+
+/// Read `dependencies` and `devDependencies` from package.json, returning all package names.
+fn read_package_json_deps(app_dir: &Path) -> HashSet<String> {
+    let pkg_path = app_dir.join("package.json");
+    let mut deps = HashSet::new();
+
+    let content = match std::fs::read_to_string(&pkg_path) {
+        Ok(c) => c,
+        Err(_) => return deps,
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return deps,
+    };
+
+    for section in ["dependencies", "devDependencies"] {
+        if let Some(obj) = value.get(section).and_then(|v| v.as_object()) {
+            for key in obj.keys() {
+                deps.insert(key.clone());
+            }
+        }
+    }
+
+    deps
 }
 
 pub async fn bun_add(app_dir: &Path, deps: &[String]) -> Result<(), String> {

--- a/crates/core/src/components/mod.rs
+++ b/crates/core/src/components/mod.rs
@@ -26,6 +26,121 @@ use url::Url;
 use crate::components::css_updater::{CssMutation, CssUpdater};
 use crate::components::models::TailwindConfig;
 
+/// Scan planned component files for 3rd-party npm imports that may not be listed
+/// in the registry spec's `dependencies` array.
+///
+/// Returns a deduplicated, sorted list of bare package names (e.g. `"ai"`, `"streamdown"`).
+///
+/// Filters out:
+/// - Relative imports (`./`, `../`)
+/// - Alias/path imports (`@/`)
+/// - Common always-present packages (`react`, `react-dom`, `next`)
+pub fn detect_external_imports(files: &[PlannedFile]) -> Vec<String> {
+    let always_present: HashSet<&str> = ["react", "react-dom", "next"].into_iter().collect();
+
+    let mut packages: BTreeSet<String> = BTreeSet::new();
+
+    for file in files {
+        // Only scan .ts/.tsx/.js/.jsx files
+        let ext = file
+            .relative_path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+        if !matches!(ext, "ts" | "tsx" | "js" | "jsx") {
+            continue;
+        }
+
+        for specifier in extract_import_specifiers(&file.content) {
+            // Skip relative imports
+            if specifier.starts_with('.') {
+                continue;
+            }
+
+            // Skip project alias imports (@/ is a path alias, not an npm scope)
+            if specifier.starts_with("@/") {
+                continue;
+            }
+
+            // Extract bare package name:
+            // - "ai" → "ai"
+            // - "streamdown/react" → "streamdown"
+            // - "@scope/pkg" → "@scope/pkg"
+            // - "@scope/pkg/sub" → "@scope/pkg"
+            let package_name = if specifier.starts_with('@') {
+                // Scoped package: @scope/name or @scope/name/subpath
+                let parts: Vec<&str> = specifier.splitn(3, '/').collect();
+                if parts.len() >= 2 {
+                    format!("{}/{}", parts[0], parts[1])
+                } else {
+                    continue; // malformed
+                }
+            } else {
+                // Unscoped: name or name/subpath
+                specifier
+                    .split('/')
+                    .next()
+                    .unwrap_or(&specifier)
+                    .to_string()
+            };
+
+            if always_present.contains(package_name.as_str()) {
+                continue;
+            }
+
+            packages.insert(package_name);
+        }
+    }
+
+    packages.into_iter().collect()
+}
+
+/// Extract import specifiers from TypeScript/JavaScript content.
+///
+/// Finds patterns like:
+/// - `from "module"`  / `from 'module'`
+/// - `import "module"` / `import 'module'` (side-effect imports)
+fn extract_import_specifiers(content: &str) -> Vec<String> {
+    let mut specifiers = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Look for `from "..."` or `from '...'` patterns
+        if let Some(pos) = trimmed.find("from ") {
+            let after_from = &trimmed[pos + 5..].trim_start();
+            if let Some(spec) = extract_quoted_string(after_from) {
+                specifiers.push(spec);
+                continue;
+            }
+        }
+
+        // Look for side-effect imports: `import "..."` or `import '...'`
+        if let Some(after_import_kw) = trimmed.strip_prefix("import ") {
+            let after_import = after_import_kw.trim_start();
+            // Only match if the next thing is a quote (side-effect import)
+            if (after_import.starts_with('"') || after_import.starts_with('\''))
+                && let Some(spec) = extract_quoted_string(after_import)
+            {
+                specifiers.push(spec);
+            }
+        }
+    }
+
+    specifiers
+}
+
+/// Extract a quoted string value from text starting with a quote character.
+fn extract_quoted_string(s: &str) -> Option<String> {
+    let quote = s.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let rest = &s[1..];
+    let end = rest.find(quote)?;
+    Some(rest[..end].to_string())
+}
+
 /// Default shadcn/ui registry item template.
 ///
 /// IMPORTANT: /r/{name}.json is 404.
@@ -1287,6 +1402,69 @@ mod tests {
             map.get("@/hooks/use-is-in-view"),
             Some(&"@/hooks/hooks-use-is-in-view".to_string())
         );
+    }
+
+    #[test]
+    fn test_detect_external_imports() {
+        let files = vec![PlannedFile {
+            relative_path: PathBuf::from("ui/message.tsx"),
+            absolute_path: PathBuf::from("/tmp/test/src/components/ui/message.tsx"),
+            content: r#"
+import { useState } from "react";
+import { streamText } from "ai";
+import { Markdown } from "streamdown/react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { localHelper } from "./helper";
+import { otherHelper } from "../shared/utils";
+import "highlight.js/styles/github.css";
+import { SomeScoped } from "@radix-ui/react-dialog";
+"#
+            .to_string(),
+            source_component: "message".to_string(),
+        }];
+
+        let result = detect_external_imports(&files);
+
+        assert!(result.contains(&"ai".to_string()));
+        assert!(result.contains(&"streamdown".to_string()));
+        assert!(result.contains(&"highlight.js".to_string()));
+        assert!(result.contains(&"@radix-ui/react-dialog".to_string()));
+        // Should NOT contain:
+        assert!(!result.contains(&"react".to_string()));
+        assert!(!result.iter().any(|s| s.starts_with("@/")));
+        assert!(!result.iter().any(|s| s.starts_with('.')));
+    }
+
+    #[test]
+    fn test_detect_external_imports_skips_non_ts_files() {
+        let files = vec![PlannedFile {
+            relative_path: PathBuf::from("readme.md"),
+            absolute_path: PathBuf::from("/tmp/test/readme.md"),
+            content: r#"import { foo } from "some-package""#.to_string(),
+            source_component: "readme".to_string(),
+        }];
+
+        let result = detect_external_imports(&files);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_extract_import_specifiers() {
+        let content = r#"
+import { useState } from "react";
+import { streamText } from 'ai';
+import "side-effect-pkg";
+import type { Foo } from "type-pkg";
+const x = require("not-matched");
+"#;
+        let specs = extract_import_specifiers(content);
+        assert!(specs.contains(&"react".to_string()));
+        assert!(specs.contains(&"ai".to_string()));
+        assert!(specs.contains(&"side-effect-pkg".to_string()));
+        assert!(specs.contains(&"type-pkg".to_string()));
+        // require() is not matched
+        assert!(!specs.contains(&"not-matched".to_string()));
     }
 
     #[test]

--- a/crates/core/src/search/docs_index.rs
+++ b/crates/core/src/search/docs_index.rs
@@ -366,10 +366,21 @@ impl SDKDocsIndex {
                     return Ok(Vec::new());
                 }
 
-                tracing::debug!("search: Executing FTS5 query for '{}'", query);
+                // Enhance query: if it contains a PascalCase term, boost entity column
+                let sanitized = enhance_fts5_query(&sanitized);
 
+                tracing::debug!(
+                    "search: Executing FTS5 query '{}' (original: '{}')",
+                    sanitized,
+                    query
+                );
+
+                // bm25() weights: entity(5.0), text(1.0), operation(1.0),
+                // symbols(3.0), service(1.0), chunk_index(0.0)
+                // Column order in FTS5 table: text, service, entity, operation, symbols
                 let rows = sqlx::query(&format!(
-                    "SELECT text, source_file, rank FROM \"{table_name}\" \
+                    "SELECT text, source_file, bm25(\"{table_name}\", 1.0, 1.0, 5.0, 1.0, 3.0) AS rank \
+                     FROM \"{table_name}\" \
                      WHERE \"{table_name}\" MATCH ?1 \
                      ORDER BY rank \
                      LIMIT ?2"
@@ -399,6 +410,59 @@ impl SDKDocsIndex {
             }
         }
     }
+}
+
+/// Enhance an FTS5 query to boost entity/class matches.
+///
+/// - If query contains a PascalCase token (e.g. `GenieAttachment`), adds
+///   `{entity}:token` to boost entity column matches.
+/// - Strips hint words like "fields" or "attributes" and uses them to
+///   filter toward dataclass documentation.
+fn enhance_fts5_query(sanitized: &str) -> String {
+    let hint_words: &[&str] = &["fields", "attributes", "members", "properties"];
+
+    let tokens: Vec<&str> = sanitized.split_whitespace().collect();
+    if tokens.is_empty() {
+        return sanitized.to_string();
+    }
+
+    let mut entity_terms = Vec::new();
+    let mut regular_terms = Vec::new();
+
+    for token in &tokens {
+        let clean = token.trim_matches('"');
+        if hint_words.contains(&clean.to_lowercase().as_str()) {
+            // Don't add hint words to the query — they just guide boosting
+            continue;
+        }
+        if is_pascal_case(clean) {
+            // Add both as regular term and as entity-boosted term
+            entity_terms.push(format!("entity:{token}"));
+            regular_terms.push(token.to_string());
+        } else {
+            regular_terms.push(token.to_string());
+        }
+    }
+
+    if entity_terms.is_empty() {
+        return regular_terms.join(" OR ");
+    }
+
+    // Combine: entity-boosted terms + regular terms
+    let mut parts = entity_terms;
+    parts.extend(regular_terms);
+    parts.join(" OR ")
+}
+
+/// Check if a string looks like PascalCase (starts with uppercase, contains lowercase).
+fn is_pascal_case(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_uppercase() => {}
+        _ => return false,
+    }
+    // Must contain at least one lowercase letter (to distinguish from ALL_CAPS)
+    s.chars().any(|c| c.is_ascii_lowercase())
 }
 
 #[cfg(test)]
@@ -506,5 +570,38 @@ mod tests {
         assert_eq!(results.len(), 1);
         let text: String = results[0].get("text");
         assert!(text.contains("clusters"));
+    }
+
+    #[test]
+    fn test_is_pascal_case() {
+        assert!(is_pascal_case("GenieAttachment"));
+        assert!(is_pascal_case("ClustersAPI"));
+        assert!(is_pascal_case("Abc"));
+        assert!(!is_pascal_case("abc"));
+        assert!(!is_pascal_case("ABC")); // ALL_CAPS, not PascalCase
+        assert!(!is_pascal_case("create"));
+        assert!(!is_pascal_case("123"));
+    }
+
+    #[test]
+    fn test_enhance_fts5_query_pascal_case() {
+        let result = enhance_fts5_query("\"GenieAttachment\"");
+        assert!(result.contains("entity:\"GenieAttachment\""));
+        assert!(result.contains("\"GenieAttachment\""));
+    }
+
+    #[test]
+    fn test_enhance_fts5_query_with_fields_hint() {
+        let result = enhance_fts5_query("\"GenieAttachment\" \"fields\"");
+        assert!(result.contains("entity:\"GenieAttachment\""));
+        // "fields" is a hint word and should be stripped
+        assert!(!result.contains("\"fields\""));
+    }
+
+    #[test]
+    fn test_enhance_fts5_query_plain() {
+        let result = enhance_fts5_query("\"create\" \"clusters\"");
+        // No PascalCase terms, should just join with OR
+        assert_eq!(result, "\"create\" OR \"clusters\"");
     }
 }

--- a/crates/mcp/src/tools/registry.rs
+++ b/crates/mcp/src/tools/registry.rs
@@ -155,12 +155,39 @@ impl ApxServer {
         };
 
         match add_components(&path, &[input], args.force).await {
-            Ok(_result) => {
+            Ok(result) => {
                 tracing::info!("Component {} added successfully", args.component_id);
-                Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Successfully added component: {}",
-                    args.component_id
-                ))]))
+
+                #[derive(serde::Serialize)]
+                struct AddResponse {
+                    component_id: String,
+                    written_files: Vec<String>,
+                    unchanged_files: Vec<String>,
+                    dependencies_installed: Vec<String>,
+                    auto_detected_deps: Vec<String>,
+                    css_updated: Option<String>,
+                    warnings: Vec<String>,
+                }
+
+                let response = AddResponse {
+                    component_id: args.component_id,
+                    written_files: result
+                        .written_paths
+                        .iter()
+                        .map(|p| apx_core::components::utils::format_relative_path(p, &path))
+                        .collect(),
+                    unchanged_files: result
+                        .unchanged_paths
+                        .iter()
+                        .map(|p| apx_core::components::utils::format_relative_path(p, &path))
+                        .collect(),
+                    dependencies_installed: result.dependencies_installed,
+                    auto_detected_deps: result.auto_detected_deps,
+                    css_updated: result.css_updated_path,
+                    warnings: result.warnings,
+                };
+
+                Ok(CallToolResult::from_serializable(&response))
             }
             Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
                 "Failed to add component: {e}"

--- a/src/apx/templates/addons/claude/CLAUDE.md.jinja2
+++ b/src/apx/templates/addons/claude/CLAUDE.md.jinja2
@@ -17,7 +17,8 @@ Full-stack Databricks App built with apx (React + Vite frontend, FastAPI backend
 - **Python:** Always use `uv` (never `pip`)
 
 ## Component Management
-- **Finding components:** Use MCP `search_registry_components` to search for available shadcn/ui components
+- **Check configured registries first:** Before building custom components, check `[tool.apx.ui.registries]` in `pyproject.toml` for domain-specific registries (e.g. `@ai-elements` for chat/AI, `@animate-ui` for animations). Use `list_registry_components` with the registry name to browse available components.
+- **Finding components:** Use MCP `search_registry_components` to search across all configured registries. Results from project-configured registries are boosted.
 - **Adding components:** Use MCP `add_component` or CLI `apx components add <component> --yes` to add components
 - **Component location:** If component was added to a wrong location (e.g. stored into `src/components` instead of `src/{{app_name}}/ui/components`), move it to the proper folder
 - **Component organization:** Prefer grouping components by functionality rather than by file type (e.g. `src/{{app_name}}/ui/components/chat/`)
@@ -60,7 +61,9 @@ This project is configured with the **apx MCP server** (see `.mcp.json`). Always
 | `check` | Check project code for errors (runs tsc and ty checks in parallel) |
 | `refresh_openapi` | Regenerate OpenAPI schema and API client |
 | `search_registry_components` | Search shadcn registry components using semantic search |
+| `list_registry_components` | List all available components in a specific registry |
 | `add_component` | Add a component to the project |
+| `routes` | List all API routes with parameters, schemas, and generated hook names |
 | `docs` | Search Databricks SDK documentation for code examples and API references |
 | `databricks_apps_logs` | Fetch logs from deployed Databricks app using Databricks CLI |
 | `get_route_info` | Get code example for using a specific API route |


### PR DESCRIPTION
## Summary
- **Structured add_component response:** Replace plain-text success message with JSON including `written_files`, `unchanged_files`, `dependencies_installed`, `auto_detected_deps`, `css_updated`, and `warnings`
- **Auto-detect missing npm deps:** Scan component file imports for 3rd-party packages not in `package.json` or registry spec deps, auto-install them via `bun add`
- **Improved docs search ranking:** Add `bm25()` column weighting (entity=5.0, symbols=3.0) and PascalCase entity boosting with hint word stripping ("fields", "attributes")
- **CLAUDE.md template:** Add registry-aware guidance and missing `list_registry_components` + `routes` tools to MCP reference table

## Test plan
- [x] `cargo build` passes
- [x] `cargo test -p apx-core` — all 162 tests pass (7 new)
- [x] `cargo clippy` + `cargo fmt` clean
- [ ] Manual: run MCP server, call `add_component` for a component with 3rd-party imports, verify structured response with `auto_detected_deps`
- [ ] Manual: search "GenieAttachment fields" in docs tool, verify dataclass fields in top results
- [ ] Manual: `apx init` a new project, verify CLAUDE.md contains registry guidance

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)