### PR TITLE
🐛 Fix native TLS roots for WebSocket connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6853,6 +6853,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rmcp = { version = "0.15", features = ["server", "transport-io", "schemars"] }
 # Web server
 axum = { version = "0.8.8", features = ["ws"] }
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "stream", "rustls", "http2", "charset", "system-proxy"] }
-tokio-tungstenite = { version = "0.28", features = ["connect", "handshake", "stream", "__rustls-tls"] }
+tokio-tungstenite = { version = "0.28", features = ["connect", "rustls-tls-native-roots"] }
 
 # OpenTelemetry
 opentelemetry = "0.29"


### PR DESCRIPTION
## Summary
- Switch `tokio-tungstenite` from internal `__rustls-tls` feature to `rustls-tls-native-roots` so WebSocket connections use the system's native certificate store
- Fixes TLS certificate validation failures when streaming app logs

Closes #120

## Test plan
- [ ] Verify `databricks_apps_logs` MCP tool successfully connects and streams logs from a deployed app
- [ ] Confirm no TLS certificate errors on workspace environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)