### PR TITLE
docs: split install commands into separate macOS/Linux and Windows blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@
 
 Install `apx`:
 
+**macOS/Linux:**
 ```bash
-# macOS/Linux
 curl -fsSL https://databricks-solutions.github.io/apx/install.sh | sh
+```
 
-# Windows
+**Windows:**
+```powershell
 irm https://databricks-solutions.github.io/apx/install.ps1 | iex
 ```
 


### PR DESCRIPTION
Closes #132

## Summary

- Separates the single install code block (containing both macOS/Linux and Windows commands) into two distinct, labeled code blocks
- Makes it easier for users to copy the correct install command for their platform without having to select around comments
- Uses \`powershell\` syntax highlighting for the Windows block since it uses PowerShell (\`irm ... | iex\`)

## Test plan

- [ ] Verify the README renders correctly on GitHub with two separate code blocks
- [ ] Confirm macOS/Linux block uses \`bash\` highlighting
- [ ] Confirm Windows block uses \`powershell\` highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)